### PR TITLE
Add environment variables to set specific kernel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,17 @@ QUEUE=default APP_INCLUDE=var/bootstrap.php.cache REDIS_BACKEND=127.0.0.1:6379 .
 PREFIX="my_app:" REDIS_BACKEND=127.0.0.1:6379 ./vendor/bin/resque-scheduler
 ```
 
-Add `VVERBOSE=1` to the environment to get more logging.
+* Add `VVERBOSE=1` to the environment to get more logging.
 
+It can be useful to decouple the queueing (master) and execution (slave) of jobs in a
+micro service architecture. For this it can be necessary to set specific `kernel_options`
+for a worker if they differ from the master. 
+
+* Add `KERNEL_CLASS` with the fully qualified class name of the kernel to override the `kernel.root_dir` option.
+  If your kernel is not located in the root namespace (like in symfony flex applications),
+  this is the only way to specify the class name of the kernel class.
+* Add `SYMFONY_ENV` or `APP_ENV` to override the `kernel.environment` option.
+* Add `SYMFONY_DEBUG` or `APP_DEBUG` to override the `kernel.debug` option.
 
 ## Install
 

--- a/src/Mcfedr/ResqueQueueDriverBundle/Resque/Job.php
+++ b/src/Mcfedr/ResqueQueueDriverBundle/Resque/Job.php
@@ -26,10 +26,13 @@ class Job
      */
     public $job;
 
+    /**
+     * @throws UnexpectedJobDataException if resque message missing data fields name, arguments, kernel_options or environment variables are missing
+     */
     public function perform()
     {
-        if (!is_array($this->args) || !isset($this->args['name']) || !isset($this->args['arguments']) || !isset($this->args['kernel_options'])) {
-            throw new UnexpectedJobDataException('Resque message missing data fields name, arguments and kernel_options');
+        if (!$this->isJobConfigured() || !$this->isKernelClassConfigured() || !$this->isKernelEnvironmentConfigured() || !$this->isKernelDebugConfigured()) {
+            throw new UnexpectedJobDataException('Resque message missing data fields name, arguments, kernel_options or environment variables are missing');
         }
 
         $this->getContainer()->get('mcfedr_queue_manager.job_executor')->executeJob(new ResqueJob($this->args, null, null, $this->queue, static::class, null));
@@ -39,6 +42,38 @@ class Job
      * @var KernelInterface
      */
     private $kernel = null;
+
+    /**
+     * @return bool
+     */
+    private function isJobConfigured()
+    {
+        return is_array($this->args) && isset($this->args['name']) && isset($this->args['arguments']);
+    }
+
+    /**
+     * @return bool
+     */
+    private function isKernelClassConfigured()
+    {
+        return strlen(getenv('KERNEL_CLASS')) || isset($this->args['kernel_options']['kernel.root_dir']);
+    }
+
+    /**
+     * @return bool
+     */
+    private function isKernelEnvironmentConfigured()
+    {
+        return strlen(getenv('SYMFONY_ENV')) || strlen(getenv('APP_ENV')) || isset($this->args['kernel_options']['kernel.environment']);
+    }
+
+    /**
+     * @return bool
+     */
+    private function isKernelDebugConfigured()
+    {
+        return strlen(getenv('SYMFONY_DEBUG')) || strlen(getenv('APP_DEBUG')) || isset($this->args['kernel_options']['kernel.debug']);
+    }
 
     /**
      * @return ContainerInterface
@@ -54,12 +89,34 @@ class Job
     }
 
     /**
-     * This is largely copied from how the test client finds and setups a kernel.
-     *
      * @return KernelInterface
      */
     private function createKernel()
     {
+        $kernelClass = $this->getKernelClass();
+
+        return new $kernelClass($this->getKernelEnvironment(), $this->getKernelDebug());
+    }
+
+    public function tearDown()
+    {
+        if ($this->kernel) {
+            $this->kernel->shutdown();
+        }
+    }
+
+    /**
+     * This is largely copied from how the test client finds and setups a kernel.
+     *
+     * @return string
+     */
+    private function getKernelClass()
+    {
+        $env = getenv('KERNEL_CLASS');
+        if (strlen($env)) {
+            return $env;
+        }
+
         $iterator = (new Finder())
             ->name('*Kernel.php')
             ->depth(0)
@@ -72,16 +129,42 @@ class Job
 
         require_once $file;
 
-        return new $class(
-            isset($this->args['kernel_options']['kernel.environment']) ? $this->args['kernel_options']['kernel.environment'] : 'dev',
-            isset($this->args['kernel_options']['kernel.debug']) ? $this->args['kernel_options']['kernel.debug'] : true
-        );
+        return $class;
     }
 
-    public function tearDown()
+    /**
+     * @return string
+     */
+    private function getKernelEnvironment()
     {
-        if ($this->kernel) {
-            $this->kernel->shutdown();
+        $env = getenv('SYMFONY_ENV');
+        if (strlen($env)) {
+            return $env;
         }
+
+        $env = getenv('APP_ENV');
+        if (strlen($env)) {
+            return $env;
+        }
+
+        return isset($this->args['kernel_options']['kernel.environment']) ? $this->args['kernel_options']['kernel.environment'] : 'dev';
+    }
+
+    /**
+     * @return bool
+     */
+    private function getKernelDebug()
+    {
+        $debug = getenv('SYMFONY_DEBUG');
+        if (strlen($debug)) {
+            return '1' === $debug;
+        }
+
+        $debug = getenv('APP_DEBUG');
+        if (strlen($debug)) {
+            return '1' === $debug;
+        }
+
+        return isset($this->args['kernel_options']['kernel.debug']) ? $this->args['kernel_options']['kernel.debug'] : true;
     }
 }

--- a/tests/Mcfedr/ResqueQueueDriverBundle/Tests/DependencyInjection/McfedrResqueQueueDriverExtensionTest.php
+++ b/tests/Mcfedr/ResqueQueueDriverBundle/Tests/DependencyInjection/McfedrResqueQueueDriverExtensionTest.php
@@ -10,7 +10,7 @@ class McfedrResqueQueueDriverExtensionTest extends WebTestCase
     public function testConfiguration()
     {
         $client = static::createClient();
-        $this->assertTrue($client->getContainer()->has(ResqueQueueManager::class));
-        $this->assertTrue($client->getContainer()->has('mcfedr_queue_manager.default'));
+        $this->assertTrue($client->getContainer()->has(ResqueQueueManager::class), 'service for resque queue manager exists');
+        $this->assertTrue($client->getContainer()->has('mcfedr_queue_manager.default'), 'default manager exists');
     }
 }

--- a/tests/Mcfedr/ResqueQueueDriverBundle/Tests/Resque/JobTest.php
+++ b/tests/Mcfedr/ResqueQueueDriverBundle/Tests/Resque/JobTest.php
@@ -5,6 +5,9 @@ namespace Mcfedr\ResqueQueueDriverBundle\Tests\Resque\Job;
 use Mcfedr\ResqueQueueDriverBundle\Resque\Job;
 use Mcfedr\ResqueQueueDriverBundle\Worker\TestWorker;
 
+/**
+ * @backupGlobals enabled
+ */
 class JobTest extends \PHPUnit_Framework_TestCase
 {
     public function testPerform()
@@ -18,6 +21,48 @@ class JobTest extends \PHPUnit_Framework_TestCase
                 'kernel.environment' => 'test',
                 'kernel.debug' => true,
             ],
+        ];
+        $job->perform();
+    }
+
+    /**
+     * @expectedException \Mcfedr\QueueManagerBundle\Exception\UnexpectedJobDataException
+     * @expectedExceptionMessage kernel_options
+     */
+    public function testMissingKernelOptions()
+    {
+        $job = new Job();
+        $job->args = [
+            'name' => TestWorker::class,
+            'arguments' => ['first' => 1, 'second' => 'second'],
+        ];
+        $job->perform();
+    }
+
+    public function testPerformWithSymfonyEnvironmentVariables()
+    {
+        putenv('KERNEL_CLASS=\TestKernel');
+        putenv('SYMFONY_ENV=dev');
+        putenv('SYMFONY_DEBUG=1');
+
+        $job = new Job();
+        $job->args = [
+            'name' => TestWorker::class,
+            'arguments' => ['first' => 1, 'second' => 'second'],
+        ];
+        $job->perform();
+    }
+
+    public function testPerformWithSymfonyFlexEnvironmentVariables()
+    {
+        putenv('KERNEL_CLASS=\TestKernel');
+        putenv('APP_ENV=dev');
+        putenv('APP_DEBUG=1');
+
+        $job = new Job();
+        $job->args = [
+            'name' => TestWorker::class,
+            'arguments' => ['first' => 1, 'second' => 'second'],
         ];
         $job->perform();
     }


### PR DESCRIPTION
- decouple master (add to queue) and slave (executing job) system
- prepare for docker (use environment variables)
- support kernel classes not in root namespace (symfony flex) 